### PR TITLE
Fix: Shiny version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ rpds-py==0.30.0
 scipy==1.17.1
 seaborn==0.13.2
 setuptools==82.0.0
-shiny==0.0.0
+shiny==1.4.0
 shinywidgets==0.7.1
 six==1.17.0
 stack_data==0.6.3


### PR DESCRIPTION
Closes #63 

* Fixed Shiny version in requirements.txt to 1.4.0 so the deployment runs on posit.