### PR TITLE
Feedback update eric

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -119,8 +119,11 @@ app_ui = ui.page_navbar(
         ui.page_sidebar(
             # Filter Section
             ui.sidebar(
-                ui.h4("Filters"),
-                ui.hr(),
+                ui.div(
+                    ui.h4("Filters"),
+                    ui.hr(),
+                    {"class": "sidebar-fixed-header"},
+                ),
                 ui.h5("Date Range and Population"),
                 # ADDED: DATE SLIDER
                 ui.h5("Date Range"),
@@ -185,7 +188,48 @@ app_ui = ui.page_navbar(
 
             ui.tags.style("""
                 .bslib-sidebar-layout > .collapse-toggle {
-                    top: 56px !important;
+                    position: fixed;
+                    right: auto !important;
+                    z-index: 1031;
+                }
+
+                .bslib-sidebar-layout > .collapse-toggle[aria-expanded="true"] {
+                    top: 78px !important;
+                    left: calc(var(--_sidebar-width, 250px) - 40px) !important;
+                    transform: none;
+                }
+
+                .bslib-sidebar-layout > .collapse-toggle[aria-expanded="false"] {
+                    top: 50% !important;
+                    left: 10px !important;
+                    transform: translateY(-50%);
+                }
+                
+                .bslib-sidebar-layout > .sidebar {
+                    position: fixed;
+                    top: 56px;
+                    bottom: 0;
+                    width: var(--_sidebar-width, 250px);
+                    background: white;
+                    overflow-y: auto;
+                    overflow-x: hidden;
+                }
+
+                .bslib-sidebar-layout > .sidebar .sidebar-fixed-header {
+                    position: sticky;
+                    top: 0;
+                    z-index: 1030;
+                    background: white;
+                    padding-top: 0.75rem;
+                }
+
+                .bslib-sidebar-layout > .sidebar .sidebar-fixed-header h4 {
+                    margin: 0;
+                }
+
+                .bslib-sidebar-layout > .sidebar .sidebar-fixed-header hr {
+                    margin-top: 0.75rem;
+                    margin-bottom: 0;
                 }
                 
                 .fixed-main-header {


### PR DESCRIPTION
Issue #83 
- Put KPI's floating at top
- Scrollable filter section with Filter and collapse fixed at top
- KPI fixed positioning works with collapsed filter
- fixed navbar positioning

Base dashboard
<img width="1344" height="589" alt="image" src="https://github.com/user-attachments/assets/3fe1c2ef-d4d4-41a2-a701-c9dd53bf3c10" />

Navbar, Title and KPI stays when scrolling 
<img width="1114" height="786" alt="image" src="https://github.com/user-attachments/assets/922a63ce-a61e-48e6-80e3-578fac1581af" />

Filter section has scroll bar and the collapse and Filter title are fixed 
<img width="1360" height="593" alt="image" src="https://github.com/user-attachments/assets/722472de-dca3-46ee-a370-65a49fd15e76" />

Dashboard still works when filters collapsed, the floating KPI also adjusts 
<img width="1126" height="785" alt="image" src="https://github.com/user-attachments/assets/0d37ffc2-bf25-4059-821e-66236355b1fd" />
