### PR TITLE
Set default and updated inputs for plots

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -15,6 +15,7 @@ cities = pd.read_csv("data/raw/uscities_raw.csv")
 cities = cities[cities["state_name"] != "Puerto Rico"]
 cities = cities[["city", "state_id", "lat", "lng"]]
 
+
 # Merge Crime and City Data for Map Plot
 df_merged = pd.merge(df_raw, cities, how="inner", on=["city", "state_id"])
 
@@ -88,14 +89,31 @@ CRIME_CONFIG = {
     "violent": {
         "color": "#800000",
         "column": "violent_crime",
+        "per_100k_column": "violent_per_100k",
         "title": "Violent Crime",
     },
-    "homs": {"color": "#191970", "column": "homs_sum", "title": "Homicides"},
-    "rape": {"color": "#006064", "column": "rape_sum", "title": "Rapes"},
-    "rob": {"color": "#A0522D", "column": "rob_sum", "title": "Robberies"},
+    "homs": {
+        "color": "#191970",
+        "column": "homs_sum",
+        "per_100k_column": "homs_per_100k",
+        "title": "Homicides",
+    },
+    "rape": {
+        "color": "#006064",
+        "column": "rape_sum",
+        "per_100k_column": "rape_per_100k",
+        "title": "Rapes",
+    },
+    "rob": {
+        "color": "#A0522D",
+        "column": "rob_sum",
+        "per_100k_column": "rob_per_100k",
+        "title": "Robberies",
+    },
     "agg_ass": {
         "color": "#2F4F4F",
         "column": "agg_ass_sum",
+        "per_100k_column": "agg_ass_per_100k",
         "title": "Aggravated Assault",
     },
 }
@@ -119,8 +137,9 @@ app_ui = ui.page_sidebar(
             "Select Year",
             min=int(df_merged["year"].min()),
             max=int(df_merged["year"].max()),
-            value=[int(df_merged["year"].min()), int(df_merged["year"].max())],
-            step=1
+            value=[int(df_merged["year"].max()) - 4, int(df_merged["year"].max())],
+            step=1,
+            sep=""
         ),
         ui.hr(),
         ui.input_slider(
@@ -162,12 +181,12 @@ app_ui = ui.page_sidebar(
         # Aggregated crime filter
         ui.input_slider(
             "violent_range",
-            "Violent Crime Range",
-            min=int(df_raw["violent_crime"].min()),
-            max=int(df_raw["violent_crime"].max()),
+            "Violent Crimeper 100k Range",
+            min=int(df_raw["violent_per_100k"].min()),
+            max=int(df_raw["violent_per_100k"].max()),
             value=(
-                int(df_raw["violent_crime"].min()),
-                int(df_raw["violent_crime"].max()),
+                int(df_raw["violent_per_100k"].min()),
+                int(df_raw["violent_per_100k"].max()),
             ),
         ),
     ),
@@ -196,7 +215,7 @@ app_ui = ui.page_sidebar(
         ui.column(
             12,
             ui.card(
-                ui.h5("Violent crime over time"),
+                ui.h5("Crime Rate Over Time (per 100k)"),
                 output_widget("line_plot"),
             )
         ),
@@ -242,10 +261,10 @@ def server(input, output, session):
             df = df[df["city"].isin(selected)]
 
         # Violent range filter
-        df["violent_crime"] = pd.to_numeric(df["violent_crime"], errors="coerce")
-        df = df.dropna(subset=["violent_crime"])
+        df["violent_per_100k"] = pd.to_numeric(df["violent_per_100k"], errors="coerce")
+        df = df.dropna(subset=["violent_per_100k"])
         vmin, vmax = input.violent_range()
-        df = df[(df["violent_crime"] >= vmin) & (df["violent_crime"] <= vmax)]
+        df = df[(df["violent_per_100k"] >= vmin) & (df["violent_per_100k"] <= vmax)]
 
         # Crime category filter
         category = str(input.crime_category())
@@ -306,13 +325,13 @@ def server(input, output, session):
 
         category = str(input.crime_category())
         config = CRIME_CONFIG.get(category, CRIME_CONFIG["violent"])
-        crime_col = config["column"]
+        per_100k_col = config["per_100k_column"]
         crime_title = config["title"]
 
         df["year"] = pd.to_numeric(df["year"], errors="coerce")
-        df[crime_col] = pd.to_numeric(df[crime_col], errors="coerce")
+        df[per_100k_col] = pd.to_numeric(df[per_100k_col], errors="coerce")
 
-        df = df.dropna(subset=["year", crime_col])
+        df = df.dropna(subset=["year", per_100k_col])
 
         if df.empty:
             return (
@@ -326,30 +345,30 @@ def server(input, output, session):
 
         # If multiple cities are selected, show lines for each city. Otherwise, show aggregated line for all cities.
         if multi:
-            plot_df = df.groupby(["year", "city"], as_index=False)[crime_col].sum()
+            plot_df = df.groupby(["year", "city"], as_index=False)[per_100k_col].mean()
 
             return (
                 alt.Chart(plot_df)
                 .mark_line()
                 .encode(
-                    x=alt.X("year:Q", title="Year"),
-                    y=alt.Y(f"{crime_col}:Q", title=f"{crime_title} (count)"),
+                    x=alt.X("year:Q", title="Year", axis=alt.Axis(format="d")),
+                    y=alt.Y(f"{per_100k_col}:Q", title=f"{crime_title} (per 100k)"),
                     color=alt.Color("city:N", title="City/Dept"),
-                    tooltip=["year:Q", "city:N", f"{crime_col}:Q"],
+                    tooltip=[alt.Tooltip("year:Q", title="Year", format="d"), "city:N", f"{per_100k_col}:Q"],
                 )
                 .properties(width="container", height=340)
             )
 
         # All Cities (aggregated)
-        plot_df = df.groupby("year", as_index=False)[crime_col].sum()
+        plot_df = df.groupby("year", as_index=False)[per_100k_col].mean()
 
         return (
             alt.Chart(plot_df)
             .mark_line()
             .encode(
-                x=alt.X("year:Q", title="Year"),
-                y=alt.Y(f"{crime_col}:Q", title=f"{crime_title} (count)"),
-                tooltip=["year:Q", f"{crime_col}:Q"],
+                x=alt.X("year:Q", title="Year", axis=alt.Axis(format="d")),
+                y=alt.Y(f"{per_100k_col}:Q", title=f"{crime_title} (per 100k)"),
+                tooltip=[alt.Tooltip("year:Q", title="Year", format="d"), f"{per_100k_col}:Q"],
             )
             .properties(width="container", height=340)
         )


### PR DESCRIPTION
Issue #85 

- Date range value to temporal for line graph and date slider
- Line plots per 100K stat
- Violent crime slider for per 100k instead of total
- Opinionated defaults - choose something that stems from a user story to display as a default setting when the dashboard is opened. Compare on last 5 years vs previous 5 years in KPI's / filtered_df() to display to the dashboard - ensure this is displayed in the title.

By default shows last 5 years and now is showing per 100k violent crime instead of total for slider and line plot 
<img width="1016" height="1143" alt="image" src="https://github.com/user-attachments/assets/4ceeeedc-2869-4748-84c1-32f32b0ff7eb" />
