### PR TITLE
Update Querychat greeting to mention crime category filter

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,8 +19,7 @@ con = ibis.duckdb.connect()
 
 # Read the parquet file
 merged_table = con.read_parquet(
-    "data/processed/crime_merged.parquet",
-    table_name="crime_data"
+    "data/processed/crime_merged.parquet", table_name="crime_data"
 )
 
 # Execute once for UI defaults/app setup
@@ -141,7 +140,9 @@ max_pop = int(df_merged["total_pop"].max())
 qc = querychat.QueryChat(
     df_merged.copy(),
     "Statistics",
-    greeting="""👋 Ask me anything about US crime statistics.
+    greeting="""👋 Welcome to the USA Crime Statistics Dashboard, I am your AI data assistant.
+    Try asking about specific years, cities, or making comparisons bewteen multiple cities.
+    You can use the drop down menu above to select a diffrent crime category.
 
 * <span class="suggestion">Filter to Los Angeles only</span>
 * <span class="suggestion">Which city has the highest crime rate?</span>


### PR DESCRIPTION
Closes #156 

* Update initial greeting in querychat to make it clear that the bot cannot filter on crime category. 