### PR TITLE
Changed the crime rate per 100k KPI title to reflect current crime selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Converted dataset to parquet format for improved performance and faster loading times.
 - Data connects using ibis and duckdb for efficient querying and filtering of the parquet files.
 - Updated CONTRIBUTING.md with M3 collaboration retrospective, and M4 commitments.
-- Added a KPI output that shows the highest and lowest crime rate that is filtered on year, crime category and population. This replaces the population KPI that was there in the previous week's milestone
+- Added a KPI output that shows the highest and lowest crime rate that is filtered on year, crime category and population (#135). This replaces the population KPI that was there in the previous week's milestone. 
 
 ### Changed
 - Filter section redesigned to be more compact and user-friendly, with filters organized into collapsible sections to save space and improve navigation.
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Map plot display redesigned to remove scrollbar and bordered outline.
 - Corrected spelling mistakes in the crime category filter
 - Changed the crime rate comparison table to make city-to-city comparisons clearer (#157)
+- Changed the crime rate per 100k KPI title to reflect current crime selection (#155)
 
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -468,7 +468,7 @@ app_ui = ui.page_navbar(
                         ),
                     ),
                     ui.value_box(
-                        "Crime Rate (per 100k)",
+                        ui.output_text("crime_rate_title"),
                         ui.div(
                             ui.output_text("crime_rate"),
                             ui.div(
@@ -1238,6 +1238,13 @@ def server(input, output, session):
             f"{sign}{pct_change}% vs {yr_min}-{yr_max-1} avg",
             style=f"font-size:12px; color:{color};",
         )
+
+    @render.text
+    def crime_rate_title():
+        yr_min, yr_max = input.year_range()
+        category = str(input.crime_category())
+        title = CRIME_CONFIG.get(category, CRIME_CONFIG["violent"])["title"]
+        return f"{yr_max} {title} Rate (per 100k)"
 
     @render.text
     def dashboard_title():


### PR DESCRIPTION
## Summary
Updates the Crime Rate KPI title to reflect the selected crime category and latest year in the filter.

## Changes
- Replaced static KPI title with reactive title
- Title now displays as: "<year> <crime type> Rate (per 100k)"
- Improves clarity by showing the exact year being represented

## Example
- Before: Crime Rate (per 100k)
- After: 2015 Robbery Rate (per 100k)

## Related Issue
Closes #152